### PR TITLE
include_package_data=True, otherwise icons get lost during setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup_params = dict(
         'ci': ['coveralls', 'pycodestyle'],
     },
     package_data={},
+    include_package_data=True,
     data_files=[('icons', ['kivy_garden/mapview/icons/cluster.png',
                            'kivy_garden/mapview/icons/marker.png'])],
     entry_points={},


### PR DESCRIPTION
include_package_data=True in setup.py
otherwise the icon files dont get installed