### PR TITLE
Fix issue #40: Crash if MBTilesMapSource used

### DIFF
--- a/kivy_garden/mapview/mbtsource.py
+++ b/kivy_garden/mapview/mbtsource.py
@@ -39,9 +39,9 @@ class MBTilesMapSource(MapSource):
         cx = cy = 0.0
         cz = 5
         if "bounds" in metadata:
-            self.bounds = bounds = map(float, metadata["bounds"].split(","))
+            self.bounds = bounds = tuple(map(float, metadata["bounds"].split(",")))
         if "center" in metadata:
-            cx, cy, cz = map(float, metadata["center"].split(","))
+            cx, cy, cz = tuple(map(float, metadata["center"].split(",")))
         elif self.bounds:
             cx = (bounds[2] + bounds[0]) / 2.0
             cy = (bounds[3] + bounds[1]) / 2.0


### PR DESCRIPTION
map() creates iterable in python3, which is not desired. The bug led to crash when moving the map, happening on line `min_lon, min_lat, max_lon, max_lat = map_source.bounds` (_apply_bounds() in view.py) as map_source.bounds would be `None`.
Solved by wrapping in tuple().