### PR TITLE
Fix #44 (missing markers in Kivy 2.0.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# MapView cache
+/cache

--- a/kivy_garden/mapview/view.py
+++ b/kivy_garden/mapview/view.py
@@ -152,6 +152,10 @@ class MapMarker(ButtonBehavior, Image):
     # (internal) reference to its layer
     _layer = None
 
+    def __init__(self, **kwargs):
+        super(MapMarker, self).__init__(**kwargs)
+        self.texture_update()
+
     def detach(self):
         if self._layer:
             self._layer.remove_widget(self)


### PR DESCRIPTION
Markers do not show up in Kivy 2.0.0 (as stated in #44). This PR fixes this.

I consider this an important an urgent fix.