### PR TITLE
Apply Reverse Scrolling and Enable Drawing Linestring and Polygon Geometry as Geojson

### DIFF
--- a/kivy_garden/mapview/geojson.py
+++ b/kivy_garden/mapview/geojson.py
@@ -339,6 +339,8 @@ class GeoJsonMapLayer(MapLayer):
 
     def _geojson_part_geometry(self, geometry, properties):
         tp = geometry["type"]
+        self.tp = tp
+
         graphics = []
         if tp == "Polygon":
             tess = Tesselator()
@@ -371,8 +373,12 @@ class GeoJsonMapLayer(MapLayer):
         zoom = view.zoom
         for lon, lat in lonlats:
             p = view.get_window_xy_from(lat, lon, zoom)
-            p = p[0] - self.parent.delta_x, p[1] - self.parent.delta_y
-            p = self.parent._scatter.to_local(*p)
+
+            # Make LineString and Polygon works at the same time
+            if self.tp == "Polygon":
+                p = p[0] - self.parent.delta_x, p[1] - self.parent.delta_y
+                p = self.parent._scatter.to_local(*p)
+
             yield p
 
     def _get_color_from(self, value):

--- a/kivy_garden/mapview/view.py
+++ b/kivy_garden/mapview/view.py
@@ -651,7 +651,7 @@ class MapView(Widget):
         if self.pause_on_action:
             self._pause = True
         if "button" in touch.profile and touch.button in ("scrolldown", "scrollup"):
-            d = 1 if touch.button == "scrollup" else -1
+            d = 1 if touch.button == "scrolldown" else -1
             self.animated_diff_scale_at(d, *touch.pos)
             return True
         elif touch.is_double_tap and self.double_tap_zoom:

--- a/kivy_garden/mapview/view.py
+++ b/kivy_garden/mapview/view.py
@@ -348,7 +348,7 @@ class MapView(Widget):
     def scale(self):
         if self._invalid_scale:
             self._invalid_scale = False
-            self._scale = round(self._scatter.scale, 2)
+            self._scale = self._scatter.scale
         return self._scale
 
     def get_bbox(self, margin=0):

--- a/kivy_garden/mapview/view.py
+++ b/kivy_garden/mapview/view.py
@@ -348,7 +348,7 @@ class MapView(Widget):
     def scale(self):
         if self._invalid_scale:
             self._invalid_scale = False
-            self._scale = self._scatter.scale
+            self._scale = round(self._scatter.scale, 2)
         return self._scale
 
     def get_bbox(self, margin=0):
@@ -690,10 +690,10 @@ class MapView(Widget):
         zoom = self._zoom
         scatter = self._scatter
         scale = scatter.scale
-        if scale >= 2.0:
+        if round(scale, 2) >= 2.0:
             zoom += 1
             scale /= 2.0
-        elif scale < 1:
+        elif round(scale, 2) < 1.0:
             zoom -= 1
             scale *= 2.0
         zoom = clamp(zoom, map_source.min_zoom, map_source.max_zoom)


### PR DESCRIPTION
* Reverse Scrolling
   - The map zooms in on scroll up and zooms out on scroll down.

* Draw Linestring and Polygon
   - Adds a condition that enables drawing of Linestring and Polygon in the map.
   - Both geometries can be drawn together as children of mapview.
